### PR TITLE
Remove #[deny(warnings)] attribute from crate.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(missing_docs)]
-#![deny(warnings)]
 
 
 //! # inotify bindings for the Rust programming language


### PR DESCRIPTION
As explained here:
https://github.com/rust-unofficial/patterns/blob/ef9409a/anti_patterns/deny-warnings.md

> By disallowing the compiler to build with warnings, a crate author opts out of Rust's famed stability. Sometimes new features or old misfeatures need a change in how things are done, thus lints are written that warn for a certain grace period before being turned to deny.